### PR TITLE
feat: optionally disable AP mode

### DIFF
--- a/extra_scripts/pre.py
+++ b/extra_scripts/pre.py
@@ -41,6 +41,7 @@ def load_secrets_config():
                     "remote_url": json_config.get("REMOTE_URL", ""),
                     "refresh_interval_seconds": json_config.get("REFRESH_INTERVAL_SECONDS", 10),
                     "default_brightness": json_config.get("DEFAULT_BRIGHTNESS", 10),
+                    "enable_ap_mode": json_config.get("ENABLE_AP_MODE", True),
                     "source": "secrets.json"
                 }
         except (json.JSONDecodeError, IOError) as e:
@@ -85,6 +86,7 @@ def load_secrets_config():
                         "REFRESH_INTERVAL_SECONDS", 10
                     ),
                     "default_brightness": json_config.get("DEFAULT_BRIGHTNESS", 10),
+                    "enable_ap_mode": json_config.get("ENABLE_AP_MODE", True),
                     "source": "secrets.json",
                 }
         except (json.JSONDecodeError, IOError) as e:
@@ -115,6 +117,7 @@ def main() -> None:
             f"-DREMOTE_URL={env.StringifyMacro(config['remote_url'])}",
             f"-DREFRESH_INTERVAL_SECONDS={config['refresh_interval_seconds']}",
             f"-DDEFAULT_BRIGHTNESS={config['default_brightness']}",
+            f"-DENABLE_AP_MODE={(1 if config.get('enable_ap_mode', True) else 0)}",
         ],
     )
 
@@ -125,6 +128,7 @@ def main() -> None:
         print(f"   URL: {config['remote_url']}")
         print(f"   Refresh: {config['refresh_interval_seconds']}s")
         print(f"   Brightness: {config['default_brightness']}")
+        print(f"   AP mode enabled: {config.get('enable_ap_mode', True)}")
         if config['source'] == 'secrets.json.injected':
             print("   ℹ️  Using previously injected configuration")
     else:

--- a/secrets.json.example
+++ b/secrets.json.example
@@ -3,5 +3,6 @@
     "WIFI_PASSWORD": "PASSWORD",
     "REMOTE_URL": "http://192.168.1.10:8000/ababababab/next",
     "REFRESH_INTERVAL_SECONDS": 10,
-    "DEFAULT_BRIGHTNESS" : 30
+    "DEFAULT_BRIGHTNESS" : 30,
+    "ENABLE_AP_MODE": true
 }

--- a/secrets_place.json
+++ b/secrets_place.json
@@ -3,5 +3,6 @@
     "WIFI_PASSWORD": "XplaceholderWIFIPASSWORD________________________________________",
     "REMOTE_URL": "XplaceholderREMOTEURL___________________________________________________________________________________________________________",
     "REFRESH_INTERVAL_SECONDS": 10,
-    "DEFAULT_BRIGHTNESS": 30    
+    "DEFAULT_BRIGHTNESS": 30,
+    "ENABLE_AP_MODE": true    
 }

--- a/src/wifi.h
+++ b/src/wifi.h
@@ -5,6 +5,10 @@
 #include <esp_err.h>
 #include <esp_http_server.h>
 
+#ifndef ENABLE_AP_MODE
+#define ENABLE_AP_MODE 1
+#endif
+
 /**
  * @brief Initialize WiFi
  *


### PR DESCRIPTION
This PR adds a secret that allows to disable AP mode. I'd rather reflash the device than connect to a config portal, and I don't want anybody to be able to connect to my devices in those first 2 minutes after boot so I think it makes sense to expose this.