### PR TITLE
perf: increase display clock speed

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -19,6 +19,9 @@
   #define LAT 18
   #define OE 27
   #define CLK 15
+
+  #define CLOCK_SPEED HUB75_I2S_CFG::HZ_16M
+  #define LATCH_BLANKING 3
 #elif defined(TRONBYT_S3_WIDE)
   #define R1 4
   #define G1 5
@@ -38,6 +41,8 @@
 
   #define WIDTH 128
   #define HEIGHT 64
+  #define CLOCK_SPEED HUB75_I2S_CFG::HZ_16M
+  #define LATCH_BLANKING 3
 #elif defined(TRONBYT_S3)
   #define R1 4
   #define G1 6
@@ -55,6 +60,9 @@
   #define LAT 9
   #define OE 10
   #define CLK 11
+
+  #define CLOCK_SPEED HUB75_I2S_CFG::HZ_16M
+  #define LATCH_BLANKING 3
 #elif defined(PIXOTICKER)
   #define R1 2
   #define G1 4
@@ -128,6 +136,9 @@
   #define LAT 19
   #define OE 32
   #define CLK 33
+
+  #define CLOCK_SPEED HUB75_I2S_CFG::HZ_16M
+  #define LATCH_BLANKING 3
 #endif
 
 #ifndef WIDTH
@@ -136,6 +147,14 @@
 
 #ifndef HEIGHT
 #define HEIGHT 32
+#endif
+
+#ifndef CLOCK_SPEED
+#define CLOCK_SPEED HUB75_I2S_CFG::HZ_10M
+#endif
+
+#ifndef LATCH_BLANKING
+#define LATCH_BLANKING 1
 #endif
 
 static MatrixPanel_I2S_DMA *_matrix;
@@ -160,8 +179,8 @@ int display_initialize() {
                          HUB75_I2S_CFG::FM6126A,  // driver chip
                          HUB75_I2S_CFG::TYPE138,  // line driver
                          true,                    // double-buffering
-                         HUB75_I2S_CFG::HZ_10M,   // clock speed
-                         1,                       // latch blanking
+                         CLOCK_SPEED,             // clock speed
+                         LATCH_BLANKING,          // latch blanking
                          invert_clock_phase       // invert clock phase
   );
 


### PR DESCRIPTION
During startup, I noticed logs like this:
```
W (2292) I2S-DMA: lsbMsbTransitionBit of 0 gives 14 Hz refresh rate.
W (2299) I2S-DMA: lsbMsbTransitionBit of 1 gives 27 Hz refresh rate.
W (2306) I2S-DMA: lsbMsbTransitionBit of 2 gives 50 Hz refresh rate.
W (2313) I2S-DMA: lsbMsbTransitionBit of 3 gives 84 Hz refresh rate.
W (2320) I2S-DMA: lsbMsbTransitionBit of 3 used to achieve refresh rate of 60 Hz. Percieved colour depth to the eye may be reduced.
```

The HUB75 library auto-tunes BCM bit-plane timing. It tests how fast the panel can refresh if it includes all bit-planes vs. dropping the dimmest ones:

- `0` full color depth, very low refresh
- `1` drops 1 LSB plane, faster
- `2` drops 2, faster
- `3` drops 3, fastest

It then picks the lowest transition bit that still keeps refresh greater than 60 Hz. Increasing the clock speed allows for data to be written to the display more quickly, resulting in the library choosing a lower value and improving color accuracy.

This PR changes the transition bit from 3 to 1 on my S3-Wide, and from 1 to 0 on my Gen1 and S3.

A quick note, though: this works great on my hardware, but I can't guarantee it will work for everyone without more testing. From what I've seen, it _should_ be fully supported. Also, it doesn't result in a noticeable difference on my S3 or Gen1, but I do see the difference on my S3-Wide.

If there are any concerns, we could only change S3-Wide, or just add these as build-time variables.