### PR TITLE
chore(display): decrease min brightness to 0

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 
 #define DISPLAY_MAX_BRIGHTNESS 100
-#define DISPLAY_MIN_BRIGHTNESS 1
+#define DISPLAY_MIN_BRIGHTNESS 0
 #define DISPLAY_DEFAULT_BRIGHTNESS 30
 extern int32_t isAnimating;  // Declare the variable
 #ifdef __cplusplus


### PR DESCRIPTION
The HUB75 library was updated in e3136cf7b4d977ebb1a9a0e55b50da5e56b7e6d4 and `DISPLAY_MIN_BRIGHTNESS` needs to be 0 now to actually turn off the display