### PR TITLE
Fix OTA partition conflict by syncing otadata on fallback

### DIFF
--- a/src/ota.c
+++ b/src/ota.c
@@ -6,11 +6,29 @@
 #include <esp_system.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <esp_ota_ops.h>
+#include <esp_partition.h>
 
 static const char *TAG = "OTA";
 
 void run_ota(const char* url) {
     ESP_LOGI(TAG, "Starting OTA update from URL: %s", url);
+
+    // Sync otadata if we are running in a fallback state
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    const esp_partition_t *boot = esp_ota_get_boot_partition();
+
+    if (running && (boot == NULL || running->address != boot->address)) {
+        ESP_LOGW(TAG, "Running partition (0x%lx) != Boot partition (0x%lx). Syncing otadata...", 
+                 (unsigned long)running->address, boot ? (unsigned long)boot->address : 0);
+        esp_err_t err = esp_ota_set_boot_partition(running);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to sync otadata: %s. Aborting OTA.", esp_err_to_name(err));
+            return;
+        } else {
+            ESP_LOGI(TAG, "Otadata synced to running partition");
+        }
+    }
 
     esp_http_client_config_t config = {
         .url = url,


### PR DESCRIPTION
When the device is in a fallback state (running partition != boot partition), the standard OTA process might incorrectly select the running partition as the target, causing ESP_ERR_OTA_PARTITION_CONFLICT.

This change checks for this mismatch at the start of the OTA process and explicitly synchronizes the boot partition in otadata to match the currently running partition. This ensures the OTA engine selects the correct (non-running) partition for the update.

References #97