### PR TITLE
fix: enable partial downloads for OTA firmware files

### DIFF
--- a/src/ota.c
+++ b/src/ota.c
@@ -33,12 +33,13 @@ void run_ota(const char* url) {
     esp_http_client_config_t config = {
         .url = url,
         .crt_bundle_attach = esp_crt_bundle_attach,
-        .timeout_ms = 10000,
+        .timeout_ms = 60000,
         .keep_alive_enable = true,
     };
 
     esp_https_ota_config_t ota_config = {
         .http_config = &config,
+        .partial_http_download = true,
     };
 
     esp_err_t ret = esp_https_ota(&ota_config);


### PR DESCRIPTION
With this, I was able to successfully complete an OTA update:

```
I (89521) main: OTA URL received via WS: https://tronbyt.example.com/static/firmware/tronbyt-S3.bin
I (89523) OTA: Starting OTA update from URL: https://tronbyt.example.com/static/firmware/tronbyt-S3.bin
I (89870) main: Updated dwell_secs to 20 seconds
I (90077) gfx: Sent queued notification: {"queued":5}
I (90741) esp-x509-crt-bundle: Certificate validated
I (92205) esp-x509-crt-bundle: Certificate validated
I (92568) esp_https_ota: Starting OTA...
I (92569) esp_https_ota: Writing to <app1> partition at offset 0x400000
I (95363) esp-x509-crt-bundle: Certificate validated
I (98586) esp-x509-crt-bundle: Certificate validated
I (101751) esp-x509-crt-bundle: Certificate validated
I (104917) esp-x509-crt-bundle: Certificate validated
I (108076) esp-x509-crt-bundle: Certificate validated
I (111254) esp-x509-crt-bundle: Certificate validated
I (111822) gfx: Setting isAnimating to 0
I (111828) gfx: Loaded new webp
I (111847) gfx: Sent websocket notification: {"displaying":5}
I (111938) gfx: dwell_secs : 20
I (112054) main: Updated dwell_secs to 20 seconds
I (112175) gfx: Sent queued notification: {"queued":6}
I (114478) esp-x509-crt-bundle: Certificate validated
I (117695) esp-x509-crt-bundle: Certificate validated
I (120932) esp-x509-crt-bundle: Certificate validated
I (124101) esp-x509-crt-bundle: Certificate validated
I (127295) esp-x509-crt-bundle: Certificate validated
I (130504) esp-x509-crt-bundle: Certificate validated
I (133617) esp-x509-crt-bundle: Certificate validated
I (136789) esp-x509-crt-bundle: Certificate validated
I (139809) esp-x509-crt-bundle: Certificate validated
I (142946) esp-x509-crt-bundle: Certificate validated
I (145478) esp-x509-crt-bundle: Certificate validated
I (148038) esp-x509-crt-bundle: Certificate validated
I (148356) gfx: Setting isAnimating to 0
I (148357) gfx: Loaded new webp
I (148375) gfx: Sent websocket notification: {"displaying":6}
I (148376) gfx: dwell_secs : 20
I (148419) main: Updated dwell_secs to 20 seconds
I (148745) gfx: Sent queued notification: {"queued":7}
I (150665) esp-x509-crt-bundle: Certificate validated
I (153239) esp-x509-crt-bundle: Certificate validated
I (155839) esp-x509-crt-bundle: Certificate validated
I (157449) esp_image: segment 0: paddr=00400020 vaddr=3c0d0020 size=792dch (496348) map
I (157549) esp_image: segment 1: paddr=00479304 vaddr=3fc9b400 size=04ff4h ( 20468) 
I (157556) esp_image: segment 2: paddr=0047e300 vaddr=40374000 size=01d18h (  7448) 
I (157558) esp_image: segment 3: paddr=00480020 vaddr=42000020 size=ca188h (827784) map
I (157728) esp_image: segment 4: paddr=0054a1b0 vaddr=40375d18 size=15698h ( 87704) 
I (157746) esp_image: segment 5: paddr=0055f850 vaddr=600fe100 size=0001ch (    28) 
I (157753) esp_image: segment 0: paddr=00400020 vaddr=3c0d0020 size=792dch (496348) map
I (157855) esp_image: segment 1: paddr=00479304 vaddr=3fc9b400 size=04ff4h ( 20468) 
I (157861) esp_image: segment 2: paddr=0047e300 vaddr=40374000 size=01d18h (  7448) 
I (157863) esp_image: segment 3: paddr=00480020 vaddr=42000020 size=ca188h (827784) map
I (158035) esp_image: segment 4: paddr=0054a1b0 vaddr=40375d18 size=15698h ( 87704) 
I (158054) esp_image: segment 5: paddr=0055f850 vaddr=600fe100 size=0001ch (    28) 
I (158136) OTA: OTA Update successful. Rebooting...
```