### PR TITLE
feat: OTA progress bar

### DIFF
--- a/main/display.cpp
+++ b/main/display.cpp
@@ -303,6 +303,13 @@ void display_draw_pixel(int x, int y, uint8_t r, uint8_t g, uint8_t b) {
   }
 }
 
+void display_fill_rect(int x, int y, int w, int h, uint8_t r, uint8_t g, uint8_t b) {
+  if (_matrix != NULL) {
+    _matrix->fill(x, y, w, h, r, g, b);
+    // Note: No flip here, caller must flip
+  }
+}
+
 void draw_error_indicator_pixel(void) {
   display_draw_pixel(0, 0, 100, 0, 0);
 }

--- a/main/display.h
+++ b/main/display.h
@@ -7,7 +7,7 @@
 #define DISPLAY_MAX_BRIGHTNESS 100
 #define DISPLAY_MIN_BRIGHTNESS 0
 
-extern int32_t isAnimating;  // Declare the variable
+extern volatile int32_t isAnimating;  // Declare the variable
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -18,6 +18,7 @@ void display_shutdown(void);
 void display_draw(const uint8_t *pix, int width, int height);
 void display_clear(void);
 void display_draw_pixel(int x, int y, uint8_t r, uint8_t g, uint8_t b);
+void display_fill_rect(int x, int y, int w, int h, uint8_t r, uint8_t g, uint8_t b);
 void draw_error_indicator_pixel(void);
 void display_text(const char* text, int x, int y, uint8_t r, uint8_t g, uint8_t b, int scale);
 void display_flip(void);

--- a/main/gfx.h
+++ b/main/gfx.h
@@ -9,4 +9,6 @@ int gfx_update(void* webp, size_t len, int32_t dwell_secs);
 int gfx_get_loaded_counter(void);
 int gfx_display_asset(const char* asset_type);
 void gfx_display_text(const char* text, int x, int y, uint8_t r, uint8_t g, uint8_t b, int scale);
+void gfx_stop(void);
+void gfx_start(void);
 void gfx_shutdown(void);

--- a/main/main.c
+++ b/main/main.c
@@ -38,7 +38,7 @@
 #endif
 
 static const char* TAG = "main";
-int32_t isAnimating = 1;
+volatile int32_t isAnimating = 1;
 static int32_t app_dwell_secs = CONFIG_REFRESH_INTERVAL_SECONDS;
 // main buffer downloaded webp data
 static uint8_t* webp;
@@ -486,6 +486,7 @@ void app_main(void) {
     return;
   }
   esp_register_shutdown_handler(&wifi_shutdown);
+
   image_url = nvs_get_image_url();
 
   // Setup the display.


### PR DESCRIPTION
- Implement manual OTA loop in `ota.c` with progress bar visualization.
- Add `display_fill_rect` to `display.cpp` for drawing the progress bar.
- Introduce `gfx_stop` and `gfx_start` in `gfx.c` to pause/resume the animation task.
- Use a `paused` flag and `volatile isAnimating` to robustly stop the animation loop during OTA.
- Initialize both frame buffers in `ota.c` to prevent previous content from bleeding through during double buffering flips.

Fixes https://github.com/tronbyt/firmware-esp32/issues/119

Here's how it looks: https://vimeo.com/1157337711