### PR TITLE
deps: bump esp_websocket_client and esp-hub75

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,8 +1,8 @@
 dependencies:
-  espressif/esp_websocket_client: "1.6.0"
+  espressif/esp_websocket_client: "1.6.1"
   esp-hub75:
     git: https://github.com/esphome-libs/esp-hub75.git
-    version: "v0.3.0"
+    version: "v0.3.2"
     path: components/hub75
   libwebp:
     git: https://github.com/tronbyt/libwebp.git


### PR DESCRIPTION
esp_websocket_client 1.6.1 changelog:

* Fix race conditions, memory leak, and data loss ([23ca97d5](https://github.com/espressif/esp-protocols/commit/23ca97d5))
* Add state check in abort_connection to prevent double-close
* Fix memory leak: free errormsg_buffer on disconnect
* Reset connection state on reconnect to prevent stale data
* Implement lock ordering for separate TX lock mode
* Read buffered data immediately after connection to prevent data loss
* Added sdkconfig.ci.tx_lock config

esp-hub75 0.3.2 changelog:

* Use quadratic brightness curve to preserve midpoint at 128
* Fix non-monotonic brightness in dark colors with compressed BCM
* Fix BCM timing calculation to use actual I2S clock speed
* Add RGB565 color tests to color_test example
* Add color_test example for diagnosing display color issues
* Remove semver labels from dependabot PRs