### PR TITLE
Add client-side WebSocket keepalive and fix reconnection loop

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -686,6 +686,8 @@ void app_main(void) {
         .crt_bundle_attach = esp_crt_bundle_attach,
         .reconnect_timeout_ms = 10000,
         .network_timeout_ms = 10000,
+        .ping_interval_sec = 30,
+        .pingpong_timeout_sec = 60,
         .headers = strlen(ws_headers) > 0 ? ws_headers : NULL,
     };
     ws_handle = esp_websocket_client_init(&ws_cfg);
@@ -711,6 +713,7 @@ void app_main(void) {
                         pdMS_TO_TICKS(5000));
 
     bool was_connected = false;
+    int ws_disconnect_count = 0;
     for (;;) {
       bool is_connected = esp_websocket_client_is_connected(ws_handle);
 
@@ -720,16 +723,24 @@ void app_main(void) {
           send_client_info();
           was_connected = true;
         }
+        ws_disconnect_count = 0;
       } else {
         if (was_connected) {
           was_connected = false;
-          ESP_LOGW(TAG, "WebSocket Disconnected");
+          ESP_LOGW(TAG, "WebSocket disconnected");
         }
-        ESP_LOGW(TAG, "WebSocket not connected. Attempting to reconnect...");
-        esp_websocket_client_stop(ws_handle);
-        esp_err_t err = esp_websocket_client_start(ws_handle);
-        if (err != ESP_OK) {
-          ESP_LOGE(TAG, "Reconnection failed with error %d", err);
+        ws_disconnect_count++;
+        // Let the library's auto-reconnect handle short disconnections.
+        // Only force a stop/start cycle after 60 seconds (12 * 5s).
+        if (ws_disconnect_count >= 12) {
+          ESP_LOGW(TAG, "WebSocket disconnected for 60s, forcing reconnect");
+          esp_websocket_client_stop(ws_handle);
+          vTaskDelay(pdMS_TO_TICKS(1000));
+          esp_err_t err = esp_websocket_client_start(ws_handle);
+          if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Reconnection failed with error %d", err);
+          }
+          ws_disconnect_count = 0;
         }
       }
 


### PR DESCRIPTION
## Summary

- Enable ping/pong keepalive on the device's WebSocket client connection (30s ping interval, 60s pong timeout) to detect silently dead connections from the client side
- Fix the main loop reconnection logic that was fighting the ESP-IDF library's built-in auto-reconnect by stopping/starting the client every 5 seconds

## Problem

When a WebSocket connection silently dies (NAT timeout, WiFi roam, half-open TCP), the device has no way to detect it from its side. It continues to report `is_connected = true` and sits idle, never receiving new images. The only recovery is a power cycle or the server detecting the dead connection via its own keepalive.

Additionally, the reconnection loop calls `esp_websocket_client_stop()` + `esp_websocket_client_start()` every 5 seconds when disconnected, which preempts the library's own auto-reconnect timer (`reconnect_timeout_ms = 10000`). The library never gets a chance to complete its reconnection attempt before being interrupted.

## Changes

### 1. Client-side WebSocket keepalive

Added `ping_interval_sec = 30` and `pingpong_timeout_sec = 60` to `esp_websocket_client_config_t`. The ESP-IDF WebSocket client will now:
- Send a ping frame every 30 seconds
- Close the connection if no pong is received within 60 seconds
- Trigger `WEBSOCKET_EVENT_DISCONNECTED`, enabling the existing reconnection logic

This matches the 30s/60s intervals commonly used for WebSocket keepalive (and already used on the server side for dashboard connections).

### 2. Fix reconnection loop

Replaced the aggressive 5-second stop/start cycle with a counter-based approach:
- The library's built-in auto-reconnect handles short disconnections (< 60s)
- A forced stop/start cycle only triggers after 60 continuous seconds of disconnection (12 iterations × 5s)
- Adds a 1-second delay between stop and start to allow clean teardown

## Testing

Tested on a Tidbyt Gen1 device running firmware 1.5.5 with a self-hosted Tronbyt server. The device now recovers from server restarts and network interruptions within ~60 seconds without manual intervention.

## Related

- Server-side WebSocket keepalive was added separately (server sends pings to devices). This PR adds the complementary client-side keepalive for bidirectional dead-connection detection.