### PR TITLE
feat: add runtime option to skip the boot animation

### DIFF
--- a/main/gfx.c
+++ b/main/gfx.c
@@ -39,17 +39,8 @@ static struct gfx_state *_state = NULL;
 
 static void gfx_loop(void *arg);
 static int draw_webp(const uint8_t *buf, size_t len, int32_t dwell_secs,
-                     int32_t *isAnimating);
+                     volatile int32_t *isAnimating);
 static void send_websocket_notification(int counter);
-
-static bool is_static_asset(const void *ptr) {
-  if (ptr == ASSET_BOOT_WEBP) return true;
-  if (ptr == ASSET_CONFIG_WEBP) return true;
-  if (ptr == ASSET_404_WEBP) return true;
-  if (ptr == ASSET_OVERSIZE_WEBP) return true;
-  if (ptr == ASSET_NOCONNECT_WEBP) return true;
-  return false;
-}
 
 int gfx_initialize(const char *img_url) {
   // Only initialize once
@@ -440,7 +431,7 @@ static void gfx_loop(void *args) {
 }
 
 static int draw_webp(const uint8_t *buf, size_t len, int32_t dwell_secs,
-                     int32_t *isAnimating) {
+                     volatile int32_t *isAnimating) {
   // Set up WebP decoder
   // ESP_LOGI(TAG, "starting draw_webp");
   int app_dwell_secs = dwell_secs;

--- a/main/gfx.c
+++ b/main/gfx.c
@@ -66,17 +66,19 @@ int gfx_initialize(const char *img_url) {
   ESP_LOGI(TAG, "Allocating buffer of size: %d", ASSET_BOOT_WEBP_LEN);
 
   _state = calloc(1, sizeof(struct gfx_state));
-  _state->len = ASSET_BOOT_WEBP_LEN;
   _state->paused = false;
-  ESP_LOGI(TAG, "calloc buff");
-  _state->buf = calloc(1, ASSET_BOOT_WEBP_LEN);
-  ESP_LOGI(TAG, "done calloc, copying");
-  if (_state->buf == NULL) {
-    ESP_LOGE("gfx", "Memory allocation failed!");
-    return 1;
+  if (!nvs_get_skip_boot_animation()) {
+    _state->len = ASSET_BOOT_WEBP_LEN;
+    ESP_LOGI(TAG, "calloc buff");
+    _state->buf = calloc(1, ASSET_BOOT_WEBP_LEN);
+    ESP_LOGI(TAG, "done calloc, copying");
+    if (_state->buf == NULL) {
+      ESP_LOGE("gfx", "Memory allocation failed!");
+      return 1;
+    }
+    memcpy(_state->buf, ASSET_BOOT_WEBP, ASSET_BOOT_WEBP_LEN);
+    ESP_LOGI(TAG, "done, copying");
   }
-  memcpy(_state->buf, ASSET_BOOT_WEBP, ASSET_BOOT_WEBP_LEN);
-  ESP_LOGI(TAG, "done, copying");
 
   _state->mutex = xSemaphoreCreateMutex();
   if (_state->mutex == NULL) {
@@ -88,6 +90,10 @@ int gfx_initialize(const char *img_url) {
   // Initialize the display
   if (display_initialize()) {
     return 1;
+  }
+
+  if (nvs_get_skip_boot_animation()) {
+    display_clear();
   }
 
   // Display version if not skipped

--- a/main/main.c
+++ b/main/main.c
@@ -121,6 +121,8 @@ static esp_err_t send_client_info(void) {
       cJSON_AddNumberToObject(ci, "wifi_power_save", nvs_get_wifi_power_save());
       cJSON_AddBoolToObject(ci, "skip_display_version",
                             nvs_get_skip_display_version());
+      cJSON_AddBoolToObject(ci, "skip_boot_animation",
+                            nvs_get_skip_boot_animation());
       cJSON_AddBoolToObject(ci, "ap_mode", nvs_get_ap_mode());
       cJSON_AddBoolToObject(ci, "prefer_ipv6", nvs_get_prefer_ipv6());
 
@@ -257,6 +259,16 @@ static void websocket_event_handler(void* handler_args, esp_event_base_t base,
                 bool val = cJSON_IsTrue(skip_ver_item);
                 nvs_set_skip_display_version(val);
                 ESP_LOGI(TAG, "Updated skip_display_version to %d", val);
+                settings_changed = true;
+              }
+
+              // Check for "skip_boot_animation"
+              cJSON* skip_boot_item =
+                  cJSON_GetObjectItem(root, "skip_boot_animation");
+              if (cJSON_IsBool(skip_boot_item)) {
+                bool val = cJSON_IsTrue(skip_boot_item);
+                nvs_set_skip_boot_animation(val);
+                ESP_LOGI(TAG, "Updated skip_boot_animation to %d", val);
                 settings_changed = true;
               }
 

--- a/main/nvs_settings.c
+++ b/main/nvs_settings.c
@@ -328,7 +328,7 @@ esp_err_t nvs_set_image_url(const char *image_url) {
     char *key_end = strchr(key_value, '&');
     size_t key_len = key_end ? (size_t)(key_end - key_value) : strlen(key_value);
     if (key_len > 0 && key_len <= MAX_API_KEY_LEN) {
-      strncpy(s_api_key, key_value, key_len);
+      memcpy(s_api_key, key_value, key_len);
       s_api_key[key_len] = '\0';
       ESP_LOGI(TAG, "Extracted API key from URL");
     }

--- a/main/nvs_settings.c
+++ b/main/nvs_settings.c
@@ -23,6 +23,7 @@
 #define NVS_KEY_SWAP_COLORS "swap_colors"
 #define NVS_KEY_WIFI_POWER_SAVE "wifi_ps"
 #define NVS_KEY_SKIP_VERSION "skip_ver"
+#define NVS_KEY_SKIP_BOOT "skip_boot"
 #define NVS_KEY_AP_MODE "ap_mode"
 #define NVS_KEY_PREFER_IPV6 "prefer_ipv6"
 #define NVS_KEY_API_KEY "api_key"
@@ -37,6 +38,7 @@ static char s_image_url[MAX_URL_LEN + 1] = {0};
 static bool s_swap_colors = false;
 static wifi_ps_type_t s_wifi_power_save = WIFI_PS_MIN_MODEM;
 static bool s_skip_display_version = false;
+static bool s_skip_boot_animation = false;
 static bool s_ap_mode = true;
 static bool s_prefer_ipv6 = false;
 static char s_api_key[MAX_API_KEY_LEN + 1] = {0};
@@ -147,6 +149,10 @@ esp_err_t nvs_settings_init(void) {
       s_skip_display_version = (val_u8 != 0);
     }
 
+    if (nvs_get_u8(nvs_handle, NVS_KEY_SKIP_BOOT, &val_u8) == ESP_OK) {
+      s_skip_boot_animation = (val_u8 != 0);
+    }
+
     if (nvs_get_u8(nvs_handle, NVS_KEY_AP_MODE, &val_u8) == ESP_OK) {
       s_ap_mode = (val_u8 != 0);
     }
@@ -247,6 +253,8 @@ bool nvs_get_swap_colors(void) { return s_swap_colors; }
 wifi_ps_type_t nvs_get_wifi_power_save(void) { return s_wifi_power_save; }
 
 bool nvs_get_skip_display_version(void) { return s_skip_display_version; }
+
+bool nvs_get_skip_boot_animation(void) { return s_skip_boot_animation; }
 
 bool nvs_get_ap_mode(void) { return s_ap_mode; }
 
@@ -367,6 +375,11 @@ esp_err_t nvs_set_skip_display_version(bool skip) {
   return ESP_OK;
 }
 
+esp_err_t nvs_set_skip_boot_animation(bool skip) {
+  s_skip_boot_animation = skip;
+  return ESP_OK;
+}
+
 esp_err_t nvs_set_ap_mode(bool ap_mode) {
   s_ap_mode = ap_mode;
   return ESP_OK;
@@ -395,6 +408,7 @@ esp_err_t nvs_save_settings(void) {
   nvs_set_u8(nvs_handle, NVS_KEY_SWAP_COLORS, s_swap_colors ? 1 : 0);
   nvs_set_u8(nvs_handle, NVS_KEY_WIFI_POWER_SAVE, (uint8_t)s_wifi_power_save);
   nvs_set_u8(nvs_handle, NVS_KEY_SKIP_VERSION, s_skip_display_version ? 1 : 0);
+  nvs_set_u8(nvs_handle, NVS_KEY_SKIP_BOOT, s_skip_boot_animation ? 1 : 0);
   nvs_set_u8(nvs_handle, NVS_KEY_AP_MODE, s_ap_mode ? 1 : 0);
   nvs_set_u8(nvs_handle, NVS_KEY_PREFER_IPV6, s_prefer_ipv6 ? 1 : 0);
 

--- a/main/nvs_settings.h
+++ b/main/nvs_settings.h
@@ -34,6 +34,7 @@ esp_err_t nvs_get_api_key(char *api_key, size_t max_len);
 bool nvs_get_swap_colors(void);
 wifi_ps_type_t nvs_get_wifi_power_save(void);
 bool nvs_get_skip_display_version(void);
+bool nvs_get_skip_boot_animation(void);
 bool nvs_get_ap_mode(void);
 bool nvs_get_prefer_ipv6(void);
 
@@ -48,6 +49,7 @@ esp_err_t nvs_set_api_key(const char *api_key);
 esp_err_t nvs_set_swap_colors(bool swap_colors);
 esp_err_t nvs_set_wifi_power_save(wifi_ps_type_t power_save);
 esp_err_t nvs_set_skip_display_version(bool skip);
+esp_err_t nvs_set_skip_boot_animation(bool skip);
 esp_err_t nvs_set_ap_mode(bool ap_mode);
 esp_err_t nvs_set_prefer_ipv6(bool prefer_ipv6);
 

--- a/main/sntp.c
+++ b/main/sntp.c
@@ -28,7 +28,10 @@ void app_sntp_config(void) {
   } else {
     // 2. Use DHCP (if enabled)
     ESP_LOGI(TAG, "Using SNTP from DHCP (fallback: pool.ntp.org)");
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     sntp_servermode_dhcp(1);
+#pragma GCC diagnostic pop
     esp_sntp_setservername(0, "pool.ntp.org");
   }
 }

--- a/main/syslog.c
+++ b/main/syslog.c
@@ -163,6 +163,7 @@ esp_err_t syslog_init(const char* addr) {
     s_port = 514;
   }
   strncpy(s_host, host_buf, sizeof(s_host) - 1);
+  s_host[sizeof(s_host) - 1] = '\0';
 
   // Resolve hostname
   struct addrinfo hints = {


### PR DESCRIPTION
I have a Tronbyt S3 on my nightstand and the boot animation is very bright. I'd like to be able to disable it for this device.

I have tested a build of this on my hardware.