### PR TITLE
fix WS premature kill/reconnect logic

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -213,7 +213,8 @@ static void websocket_event_handler(void* handler_args, esp_event_base_t base,
                 display_set_brightness((uint8_t)brightness_value);
                 ESP_LOGI(TAG, "Updated brightness to %d", brightness_value);
 #ifdef CONFIG_BOARD_TIDBYT_GEN2
-                // Sync touch control state - server brightness command means display is on
+                // Sync touch control state - server brightness command means
+                // display is on
                 display_power_on = true;
                 saved_brightness = (uint8_t)brightness_value;
 #endif
@@ -709,16 +710,45 @@ void app_main(void) {
     // Create event group for WebSocket connection
     s_ws_event_group = xEventGroupCreate();
 
-    // Start the client immediately
-    // Start once, never stop/start in the loop
-    esp_err_t err = esp_websocket_client_start(ws_handle);
-    if (err != ESP_OK) {
-      ESP_LOGE(TAG, "Failed to start WebSocket client: %d", err);
+    // Start the client with retry logic for initial failures
+    // The library's auto-reconnect only works if the client task is running,
+    // so we must ensure the initial start succeeds
+    const int max_start_retries = 5;
+    const int start_retry_delay_ms = 2000;
+    bool client_started = false;
+
+    for (int attempt = 1; attempt <= max_start_retries; attempt++) {
+      esp_err_t err = esp_websocket_client_start(ws_handle);
+      if (err == ESP_OK) {
+        ESP_LOGI(TAG, "WebSocket client started successfully");
+        client_started = true;
+        break;
+      }
+      ESP_LOGE(TAG, "Failed to start WebSocket client (attempt %d/%d): %s",
+               attempt, max_start_retries, esp_err_to_name(err));
+      if (attempt < max_start_retries) {
+        vTaskDelay(pdMS_TO_TICKS(start_retry_delay_ms));
+      }
+    }
+
+    if (!client_started) {
+      ESP_LOGE(TAG,
+               "WebSocket client failed to start after %d attempts, "
+               "will retry periodically",
+               max_start_retries);
     }
 
     bool was_connected = false;
+    int64_t last_connected_time = esp_timer_get_time();
+    const int64_t extended_disconnect_threshold_us =
+        5 * 60 * 1000000LL;  // 5 minutes
+    int64_t last_disconnect_log_time = 0;
+    const int64_t disconnect_log_interval_us =
+        60 * 1000000LL;  // Log every 60 seconds
+
     for (;;) {
       bool is_connected = esp_websocket_client_is_connected(ws_handle);
+      int64_t now = esp_timer_get_time();
 
       if (is_connected) {
         if (!was_connected) {
@@ -726,13 +756,39 @@ void app_main(void) {
           send_client_info();
           was_connected = true;
         }
+        last_connected_time = now;
+        client_started = true;  // Mark as started if we ever connect
       } else {
         if (was_connected) {
           was_connected = false;
           ESP_LOGW(TAG,
                    "WebSocket Disconnected, waiting for auto-reconnect...");
+        } else if (!client_started || (now - last_connected_time) >
+                                          extended_disconnect_threshold_us) {
+          // Either initial start failed or we've been disconnected for too long
+          // Log periodically and attempt to restart the client
+          if ((now - last_disconnect_log_time) > disconnect_log_interval_us) {
+            int64_t disconnected_secs = (now - last_connected_time) / 1000000LL;
+            ESP_LOGW(TAG,
+                     "WebSocket not connected for %lld seconds, "
+                     "attempting restart...",
+                     disconnected_secs);
+            last_disconnect_log_time = now;
+
+            // Stop and restart the client to recover from stuck states
+            esp_websocket_client_stop(ws_handle);
+            vTaskDelay(pdMS_TO_TICKS(1000));
+            esp_err_t err = esp_websocket_client_start(ws_handle);
+            if (err == ESP_OK) {
+              ESP_LOGI(TAG, "WebSocket client restarted");
+              client_started = true;
+            } else {
+              ESP_LOGE(TAG, "Failed to restart WebSocket client: %s",
+                       esp_err_to_name(err));
+            }
+          }
         }
-        // DO NOT call stop/start here — library reconnects via
+        // Normal disconnection within threshold: library reconnects via
         // reconnect_timeout_ms
       }
 
@@ -818,7 +874,8 @@ void app_main(void) {
         // Wait for gfx task to load the newly queued image before fetching the
         // next one This ensures the image has begun displaying before we fetch
         // again
-        // ESP_LOGI(TAG, "Waiting for gfx task to load new image (counter=%d)", queued_counter);
+        // ESP_LOGI(TAG, "Waiting for gfx task to load new image (counter=%d)",
+        // queued_counter);
         int timeout = 0;
         while (gfx_get_loaded_counter() != queued_counter && timeout < 20000) {
           vTaskDelay(pdMS_TO_TICKS(10));

--- a/main/main.c
+++ b/main/main.c
@@ -736,6 +736,7 @@ void app_main(void) {
                "WebSocket client failed to start after %d attempts, "
                "will retry periodically",
                max_start_retries);
+      
     }
 
     bool was_connected = false;
@@ -788,6 +789,7 @@ void app_main(void) {
             }
           }
         }
+        draw_error_indicator_pixel();
         // Normal disconnection within threshold: library reconnects via
         // reconnect_timeout_ms
       }

--- a/main/main.c
+++ b/main/main.c
@@ -158,8 +158,7 @@ static void websocket_event_handler(void* handler_args, esp_event_base_t base,
       xEventGroupSetBits(s_ws_event_group, WS_CONNECTED_BIT);
       break;
     case WEBSOCKET_EVENT_DISCONNECTED:
-      ESP_LOGI(TAG, "WEBSOCKET_EVENT_DISCONNECTED");
-      draw_error_indicator_pixel();
+      xEventGroupClearBits(s_ws_event_group, WS_CONNECTED_BIT);
       break;
     case WEBSOCKET_EVENT_DATA:
       // Process text messages (op_code == 1)
@@ -711,16 +710,11 @@ void app_main(void) {
     s_ws_event_group = xEventGroupCreate();
 
     // Start the client immediately
+    // Start once, never stop/start in the loop
     esp_err_t err = esp_websocket_client_start(ws_handle);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to start WebSocket client: %d", err);
     }
-
-    // Wait for connection with a timeout (e.g., 5 seconds)
-    // If it fails to connect in time, the loop below will handle reconnection
-    // logic
-    xEventGroupWaitBits(s_ws_event_group, WS_CONNECTED_BIT, pdFALSE, pdTRUE,
-                        pdMS_TO_TICKS(5000));
 
     bool was_connected = false;
     for (;;) {
@@ -735,14 +729,11 @@ void app_main(void) {
       } else {
         if (was_connected) {
           was_connected = false;
-          ESP_LOGW(TAG, "WebSocket Disconnected");
+          ESP_LOGW(TAG,
+                   "WebSocket Disconnected, waiting for auto-reconnect...");
         }
-        ESP_LOGW(TAG, "WebSocket not connected. Attempting to reconnect...");
-        esp_websocket_client_stop(ws_handle);
-        esp_err_t err = esp_websocket_client_start(ws_handle);
-        if (err != ESP_OK) {
-          ESP_LOGE(TAG, "Reconnection failed with error %d", err);
-        }
+        // DO NOT call stop/start here — library reconnects via
+        // reconnect_timeout_ms
       }
 
       wifi_health_check();


### PR DESCRIPTION
WSS wasn't failing for remote connections. The added latency in a remote connection surfaced the WSS reconnection bug.  The 5s timeout was too short and connections were getting killed to be restarted.