### PR TITLE
Feature/http image url reboot headers

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -869,9 +869,9 @@ void app_main(void) {
         } else {
           ESP_LOGI(TAG, "Updated image_url to %s",
                    nvs_get_image_url() != NULL ? nvs_get_image_url() : "(empty)");
+          reboot_requested = true;
         }
         free(new_image_url);
-        reboot_requested = true;
       }
 
       if (fetch_failed) {

--- a/main/main.c
+++ b/main/main.c
@@ -839,12 +839,15 @@ void app_main(void) {
       int status_code = 0;
       ESP_LOGI(TAG, "Fetching from URL: %s", image_url);
       char* ota_url = NULL;
+      char* new_image_url = NULL;
+      bool reboot_requested = false;
 
       // Start timing the HTTP fetch
       int64_t fetch_start_us = esp_timer_get_time();
       bool fetch_failed = !wifi_is_connected() ||
                           remote_get(image_url, &webp, &len, &brightness_pct,
-                                     &app_dwell_secs, &status_code, &ota_url);
+                                     &app_dwell_secs, &status_code, &ota_url,
+                                     &new_image_url, &reboot_requested);
       int64_t fetch_duration_ms =
           (esp_timer_get_time() - fetch_start_us) / 1000;
 
@@ -855,6 +858,20 @@ void app_main(void) {
         xTaskCreate(ota_task_entry, "ota_task", 8192, ota_url, 5, NULL);
         // Since we are rebooting (if successful) or failed, we might want to
         // continue or pause. If OTA failed, we continue normal operation.
+      }
+
+      if (new_image_url != NULL) {
+        ESP_LOGI(TAG, "Image URL received via HTTP: %s", new_image_url);
+        nvs_set_image_url(new_image_url);
+        esp_err_t err = nvs_save_settings();
+        if (err != ESP_OK) {
+          ESP_LOGE(TAG, "Failed to save image_url: %s", esp_err_to_name(err));
+        } else {
+          ESP_LOGI(TAG, "Updated image_url to %s",
+                   nvs_get_image_url() != NULL ? nvs_get_image_url() : "(empty)");
+        }
+        free(new_image_url);
+        reboot_requested = true;
       }
 
       if (fetch_failed) {
@@ -924,6 +941,11 @@ void app_main(void) {
         }
       }
 #endif
+
+      if (reboot_requested) {
+        ESP_LOGI(TAG, "Rebooting");
+        esp_restart();
+      }
 
       wifi_health_check();
     }

--- a/main/remote.c
+++ b/main/remote.c
@@ -7,6 +7,7 @@
 #include <esp_tls.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "gfx.h"
 #include "nvs_settings.h"
@@ -23,8 +24,18 @@ struct remote_state {
   uint8_t brightness;
   int32_t dwell_secs;
   char* ota_url;
+  char* image_url;
+  bool reboot_requested;
   bool oversize_detected;
 };
+
+static bool parse_header_bool(const char* value) {
+  if (value == NULL || value[0] == '\0') {
+    return false;
+  }
+  return strcasecmp(value, "true") == 0 || strcmp(value, "1") == 0 ||
+         strcasecmp(value, "yes") == 0;
+}
 
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
@@ -81,6 +92,13 @@ static esp_err_t _httpCallback(esp_http_client_event_t* event) {
         if (state->ota_url != NULL) free(state->ota_url);
         state->ota_url = strdup(event->header_value);
         ESP_LOGI(TAG, "Found OTA URL: %s", state->ota_url);
+      } else if (strcasecmp(event->header_key, "Tronbyt-Image-URL") == 0) {
+        if (state->image_url != NULL) free(state->image_url);
+        state->image_url = strdup(event->header_value);
+        ESP_LOGI(TAG, "Found Image URL: %s", state->image_url);
+      } else if (strcasecmp(event->header_key, "Tronbyt-Reboot") == 0) {
+        state->reboot_requested = parse_header_bool(event->header_value);
+        ESP_LOGI(TAG, "Tronbyt-Reboot value: %s", event->header_value);
       }
       break;
 
@@ -173,7 +191,8 @@ static esp_err_t _httpCallback(esp_http_client_event_t* event) {
 
 int remote_get(const char* url, uint8_t** buf, size_t* len,
                uint8_t* brightness_pct, int32_t* dwell_secs,
-               int* return_status_code, char** ota_url) {
+               int* return_status_code, char** ota_url, char** image_url,
+               bool* reboot_requested) {
   // State for processing the response
   struct remote_state state = {
       .buf =
@@ -184,6 +203,8 @@ int remote_get(const char* url, uint8_t** buf, size_t* len,
       .brightness = -1,
       .dwell_secs = -1,
       .ota_url = NULL,
+      .image_url = NULL,
+      .reboot_requested = false,
       .oversize_detected = false,
   };
 
@@ -245,6 +266,9 @@ int remote_get(const char* url, uint8_t** buf, size_t* len,
     if (state.ota_url != NULL) {
       free(state.ota_url);
     }
+    if (state.image_url != NULL) {
+      free(state.image_url);
+    }
     esp_http_client_cleanup(http);
     *return_status_code = 413;  // HTTP 413 Payload Too Large
     return 1;  // Return error so main loop doesn't process the result
@@ -260,6 +284,9 @@ int remote_get(const char* url, uint8_t** buf, size_t* len,
     if (state.ota_url != NULL) {
       free(state.ota_url);
     }
+    if (state.image_url != NULL) {
+      free(state.image_url);
+    }
     esp_http_client_cleanup(http);
     return 1;
   }
@@ -271,6 +298,8 @@ int remote_get(const char* url, uint8_t** buf, size_t* len,
   if (state.dwell_secs > -1 && state.dwell_secs < 300)
     *dwell_secs = state.dwell_secs;  // 5 minute max ?
   *ota_url = state.ota_url;
+  *image_url = state.image_url;
+  *reboot_requested = state.reboot_requested;
 
   esp_http_client_cleanup(http);
   // ESP_LOGI(TAG,"fetched new webp");

--- a/main/remote.c
+++ b/main/remote.c
@@ -253,6 +253,10 @@ int remote_get(const char* url, uint8_t** buf, size_t* len,
     if (state.buf != NULL) {
       free(state.buf);
     }
+    if (state.image_url != NULL) {
+      free(state.image_url);
+      state.image_url = NULL;
+    }
     esp_http_client_cleanup(http);
     return 1;
   }

--- a/main/remote.h
+++ b/main/remote.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
-// Retrieves url via HTTP GET. Caller is responsible for freeing buf
-// and ota_url (if not NULL) on success.
+// Retrieves url via HTTP GET. Caller is responsible for freeing buf,
+// ota_url, and image_url (if not NULL) on success.
 int remote_get(const char* url, uint8_t** buf, size_t* len,
                uint8_t* brightness_pct, int32_t* dwell_secs, int* return_code,
-               char** ota_url);
+               char** ota_url, char** image_url, bool* reboot_requested);


### PR DESCRIPTION
fixes #136 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote updates can now return a `new image URL` (and whether a reboot is requested) in HTTP response headers.
  * When provided, the device saves the image URL to persistent storage and then restarts automatically when instructed.
  * This works alongside existing remote controls for content, brightness, timing, and OTA behavior.

* **Reliability**
  * Improved handling of remote image URL and reboot signals, including safe cleanup when requests fail or return unexpected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->